### PR TITLE
Update nvm-auto-switch.rb and remove EOS.undent

### DIFF
--- a/homebrew/nvm-auto-switch.rb
+++ b/homebrew/nvm-auto-switch.rb
@@ -12,7 +12,7 @@ class NvmAutoSwitch < Formula
     prefix.install "nvm-auto-switch.sh"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<-EOS
     This will enable auto-switching of node versions specified by .nvmrc files.
     It will walk up the tree till it finds a .nvmrc file else it will use the
     version specified by the default alias in nvm.


### PR DESCRIPTION
`brew install https://raw.githubusercontent.com/lalitkapoor/nvm-auto-switch/master/homebrew/nvm-auto-switch.rb` no longer works as it complains about undefined method `undent`

Seems to work now that it is not used

I know this is a 3 year old repo so I have forked it anyway and referenced it in my dotfiles